### PR TITLE
Lowered minimum CoreML Size to 256x256 as its technically supported

### DIFF
--- a/coreml_suite/nodes.py
+++ b/coreml_suite/nodes.py
@@ -223,8 +223,8 @@ class CoreMLConverter(COREML_NODE):
                         ModelVersion.SDXL.name,
                     ],
                 ),
-                "height": ("INT", {"default": 512, "min": 512, "max": 2048, "step": 8}),
-                "width": ("INT", {"default": 512, "min": 512, "max": 2048, "step": 8}),
+                "height": ("INT", {"default": 512, "min": 256, "max": 2048, "step": 8}),
+                "width": ("INT", {"default": 512, "min": 256, "max": 2048, "step": 8}),
                 "batch_size": ("INT", {"default": 1, "min": 1, "max": 64}),
                 "attention_implementation": (
                     [


### PR DESCRIPTION
Seems the CoreML Model supports lower than 512x512 just fine so should be able to work with 256x256