### PR TITLE
fix(conversion): load .mlpackage instead of unloadable .mlmodelc

### DIFF
--- a/coreml_suite/converter.py
+++ b/coreml_suite/converter.py
@@ -1,6 +1,5 @@
 import gc
 import os
-import shutil
 import time
 
 import coremltools as ct
@@ -95,23 +94,6 @@ def get_out_path(submodule_name, model_name):
     unet_path = get_folder_paths(submodule_name)[0]
     out_path = os.path.join(unet_path, fname)
     return out_path
-
-
-def compile_coreml_model(source_model_path, output_dir, final_name):
-    """Compiles Core ML models using the coremlcompiler utility from Xcode toolchain"""
-    target_path = os.path.join(output_dir, f"{final_name}.mlmodelc")
-    if os.path.exists(target_path):
-        logger.warning(f"Found existing compiled model at {target_path}! Skipping..")
-        return target_path
-
-    logger.info(f"Compiling {source_model_path}")
-    source_model_name = os.path.basename(os.path.splitext(source_model_path)[0])
-
-    os.system(f"xcrun coremlcompiler compile {source_model_path} {output_dir}")
-    compiled_output = os.path.join(output_dir, f"{source_model_name}.mlmodelc")
-    shutil.move(compiled_output, target_path)
-
-    return target_path
 
 
 def get_sample_input(batch_size, encoder_hidden_states_shape, sample_shape):
@@ -338,14 +320,3 @@ def load_unet(ckpt_path, config_path):
         ckpt_path,
         original_config=config_path,
     )
-
-
-def compile_model(out_path, out_name, submodule_name):
-    from folder_paths import get_folder_paths
-
-    # Compile the model
-    target_path = compile_coreml_model(
-        out_path, get_folder_paths(submodule_name)[0], f"{out_name}_{submodule_name}"
-    )
-    logger.info(f"Compiled {out_path} to {target_path}")
-    return target_path

--- a/coreml_suite/lcm/converter.py
+++ b/coreml_suite/lcm/converter.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import logging
 import time
 import gc
@@ -115,23 +114,6 @@ def get_out_path(submodule_name, model_name):
     unet_path = get_folder_paths(submodule_name)[0]
     out_path = os.path.join(unet_path, fname)
     return out_path
-
-
-def compile_coreml_model(source_model_path, output_dir, final_name):
-    """Compiles Core ML models using the coremlcompiler utility from Xcode toolchain"""
-    target_path = os.path.join(output_dir, f"{final_name}.mlmodelc")
-    if os.path.exists(target_path):
-        logger.warning(f"Found existing compiled model at {target_path}! Skipping..")
-        return target_path
-
-    logger.info(f"Compiling {source_model_path}")
-    source_model_name = os.path.basename(os.path.splitext(source_model_path)[0])
-
-    os.system(f"xcrun coremlcompiler compile {source_model_path} {output_dir}")
-    compiled_output = os.path.join(output_dir, f"{source_model_name}.mlmodelc")
-    shutil.move(compiled_output, target_path)
-
-    return target_path
 
 
 def get_sample_input(batch_size, encoder_hidden_states_shape, sample_shape, scheduler):
@@ -262,17 +244,6 @@ def convert(
     logger.info(f"Saved unet into {out_path}")
 
 
-def compile_model(out_path, out_name):
-    from folder_paths import get_folder_paths
-
-    # Compile the model
-    target_path = compile_coreml_model(
-        out_path, get_folder_paths("unet")[0], f"{out_name}_unet"
-    )
-    logger.info(f"Compiled {out_path} to {target_path}")
-    return target_path
-
-
 if __name__ == "__main__":
     h = 512
     w = 512
@@ -286,4 +257,3 @@ if __name__ == "__main__":
     out_path = get_out_path("unet", f"{out_name}")
     if not os.path.exists(out_path):
         convert(out_path=out_path, sample_size=sample_size, batch_size=batch_size)
-    compile_model(out_path=out_path, out_name=out_name)

--- a/coreml_suite/lcm/nodes.py
+++ b/coreml_suite/lcm/nodes.py
@@ -66,6 +66,5 @@ class COREML_CONVERT_LCM(COREML_NODE):
                 batch_size=batch_size,
                 controlnet_support=controlnet_support,
             )
-        target_path = lcm_converter.compile_model(out_path=out_path, out_name=out_name)
 
-        return (CoreMLModel(target_path, compute_unit),)
+        return (CoreMLModel(out_path, compute_unit),)

--- a/coreml_suite/nodes.py
+++ b/coreml_suite/nodes.py
@@ -167,7 +167,7 @@ class CoreMLLoader(COREML_NODE):
 
     @classmethod
     def coreml_filenames(cls):
-        extensions = (".mlmodelc", ".mlpackage")
+        extensions = (".mlpackage",)
         all_paths = folder_paths.get_filename_list_(cls.PACKAGE_DIRNAME)[1]
         coreml_paths = folder_paths.filter_files_extensions(all_paths, extensions)
 
@@ -337,11 +337,7 @@ class CoreMLConverter(COREML_NODE):
             config_path=config_path,
             quantize_nbits=quantize_nbits,
         )
-        unet_target_path = converter.compile_model(
-            out_path=unet_out_path, out_name=out_name, submodule_name="unet"
-        )
-
-        return (CoreMLModel(unet_target_path, compute_unit),)
+        return (CoreMLModel(unet_out_path, compute_unit),)
 
     @staticmethod
     def lora_path(lora_name):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-coremlsuite"
 description = "This extension contains a set of custom nodes for ComfyUI that allow you to use Core ML models in your ComfyUI workflows."
-version = "2.0.0"
+version = "2.0.1"
 license = "MIT"
 requires-python = ">=3.12,<3.13"
 packages = [{ include = "coreml_suite" }]

--- a/uv.lock
+++ b/uv.lock
@@ -206,7 +206,7 @@ wheels = [
 
 [[package]]
 name = "comfyui-coremlsuite"
-version = "2.0.0"
+version = "2.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "coremltools" },


### PR DESCRIPTION
## Problem

The native `ct.models.MLModel` runtime introduced in the diffusers conversion path (commit `0fcc4b3`) cannot load compiled `.mlmodelc` directories — they lack the `Manifest.json` it expects. Both converters still compiled to `.mlmodelc` and returned that artifact, so loading failed with:

```
A valid manifest does not exist at path: .../<name>_unet.mlmodelc/Manifest.json
```

The UNet loader also listed `.mlmodelc` files, letting users pick a model that can never load.

## Fix

- `CoreMLConverter` and `COREML_CONVERT_LCM` return the `.mlpackage` directly instead of compiling.
- `CoreMLLoader` lists only `.mlpackage`.
- Removed the now-dead `compile_model` / `compile_coreml_model` coremlcompiler wrappers (and the unused `shutil` imports) so the broken path cannot reappear.

## Notes

- `.mlmodelc` was already unloadable under the current runtime, so no working contract is broken — this restores function. Released as patch `2.0.1`.
- Pre-existing `.mlmodelc` files in `models/unet` become orphaned (no longer listed); they can be deleted manually.

## Testing

- 100 unit tests pass (1 skipped).